### PR TITLE
Change APIServer startup message

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -87,7 +87,7 @@ func (s *APIServer) Start() error {
 		return err
 	}
 
-	s.processState.StartMessage = internal.GetAPIServerStartMessage(s.processState.URL)
+	s.processState.HealthCheckEndpoint = "/healthz"
 
 	s.URL = &s.processState.URL
 	s.CertDir = s.processState.Dir

--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -19,11 +19,5 @@ func DoAPIServerArgDefaulting(args []string) []string {
 }
 
 func GetAPIServerStartMessage(u url.URL) string {
-	if isSecureScheme(u.Scheme) {
-		// https://github.com/kubernetes/kubernetes/blob/5337ff8009d02fad613440912e540bb41e3a88b1/staging/src/k8s.io/apiserver/pkg/server/serve.go#L89
-		return "Serving securely on " + u.Host
-	}
-
-	// https://github.com/kubernetes/kubernetes/blob/5337ff8009d02fad613440912e540bb41e3a88b1/pkg/kubeapiserver/server/insecure_handler.go#L121
-	return "Serving insecurely on " + u.Host
+	return "Caches are synced for autoregister controller"
 }

--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -1,7 +1,5 @@
 package internal
 
-import "net/url"
-
 var APIServerDefaultArgs = []string{
 	"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
 	"--cert-dir={{ .CertDir }}",
@@ -16,8 +14,4 @@ func DoAPIServerArgDefaulting(args []string) []string {
 	}
 
 	return APIServerDefaultArgs
-}
-
-func GetAPIServerStartMessage(u url.URL) string {
-	return "Caches are synced for autoregister controller"
 }

--- a/integration/internal/apiserver_test.go
+++ b/integration/internal/apiserver_test.go
@@ -1,8 +1,6 @@
 package internal_test
 
 import (
-	"net/url"
-
 	. "github.com/kubernetes-sig-testing/frameworks/integration/internal"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,28 +19,5 @@ var _ = Describe("Apiserver", func() {
 		Expect(defaultedArgs).To(BeEquivalentTo([]string{
 			"--one", "--two=2",
 		}))
-	})
-})
-
-var _ = Describe("GetAPIServerStartMessage()", func() {
-	Context("when using a non tls URL", func() {
-		It("generates valid start message", func() {
-			url := url.URL{
-				Scheme: "http",
-				Host:   "some.insecure.apiserver:1234",
-			}
-			message := GetAPIServerStartMessage(url)
-			Expect(message).To(Equal("Serving insecurely on some.insecure.apiserver:1234"))
-		})
-	})
-	Context("when using a tls URL", func() {
-		It("generates valid start message", func() {
-			url := url.URL{
-				Scheme: "https",
-				Host:   "some.secure.apiserver:8443",
-			}
-			message := GetAPIServerStartMessage(url)
-			Expect(message).To(Equal("Serving securely on some.secure.apiserver:8443"))
-		})
 	})
 })

--- a/integration/internal/integration_tests/integration_test.go
+++ b/integration/internal/integration_tests/integration_test.go
@@ -122,6 +122,19 @@ func isSomethingListeningOnPort(hostAndPort string) portChecker {
 	}
 }
 
+// CheckAPIServerIsReady checks if the APIServer is really ready and not only
+// listening.
+//
+// While porting some tests in k/k
+// (https://github.com/hoegaarden/kubernetes/blob/287fdef1bd98646bc521f4433c1009936d5cf7a2/hack/make-rules/test-cmd-util.sh#L1524-L1535)
+// we found, that the APIServer was
+// listening but not serving certain APIs yet.
+//
+// We changed the readiness detection in the PR at
+// https://github.com/kubernetes-sigs/testing_frameworks/pull/48. To confirm
+// this changed behaviour does what it should do, we used the same test as in
+// k/k's test-cmd (see link above) and test if certain well-known known APIs
+// are actually available.
 func CheckAPIServerIsReady(kubeCtl *integration.KubeCtl) {
 	expectedAPIS := []string{
 		"/api/v1/namespaces/default/pods 200 OK",

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -22,8 +22,14 @@ type ProcessState struct {
 	// assume the process is ready to operate. E.g. "/healthz". If this is set,
 	// we ignore StartMessage.
 	HealthCheckEndpoint string
-	// Message to wait for on stderr. If we recieve this message, we assume the
-	// process is ready to operate. Ignored if HealthCheckEndpoint is specified.
+	// StartMessage is the message to wait for on stderr. If we recieve this
+	// message, we assume the process is ready to operate. Ignored if
+	// HealthCheckEndpoint is specified.
+	//
+	// The usage of StartMessage is discouraged, favour HealthCheckEndpoint
+	// instead!
+	//
+	// Deprecated: Use HealthCheckEndpoint in favour of StartMessage
 	StartMessage string
 	Args         []string
 }

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Start method", func() {
 		var server *ghttp.Server
 		BeforeEach(func() {
 			server = ghttp.NewServer()
-
 		})
 		AfterEach(func() {
 			server.Close()
@@ -134,6 +133,38 @@ var _ = Describe("Start method", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(server.ReceivedRequests()).To(HaveLen(4))
 				Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
+			})
+
+			Context("when the polling interval is not configured", func() {
+				It("uses the default interval for polling", func() {
+					processState.HealthCheckEndpoint = "/helathz"
+					processState.StartTimeout = 300 * time.Millisecond
+
+					url, err := url.Parse(server.URL())
+					Expect(err).NotTo(HaveOccurred())
+					processState.URL = *url
+
+					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+				})
+			})
+
+			Context("when the polling interval is configured", func() {
+				BeforeEach(func() {
+					processState.HealthCheckPollInterval = time.Millisecond * 20
+				})
+
+				It("hits the endpoint in the configured interval", func() {
+					processState.HealthCheckEndpoint = "/healthz"
+					processState.StartTimeout = 3 * processState.HealthCheckPollInterval
+
+					url, err := url.Parse(server.URL())
+					Expect(err).NotTo(HaveOccurred())
+					processState.URL = *url
+
+					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+				})
 			})
 		})
 	})

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -54,12 +54,9 @@ var _ = Describe("Start method", func() {
 			It("hits the endpoint, and successfully starts", func() {
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 100 * time.Millisecond
+				processState.URL = getServerURL(server)
 
-				url, err := url.Parse(server.URL())
-				Expect(err).NotTo(HaveOccurred())
-				processState.URL = *url
-
-				err = processState.Start(nil, nil)
+				err := processState.Start(nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(server.ReceivedRequests()).To(HaveLen(1))
 				Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
@@ -73,12 +70,9 @@ var _ = Describe("Start method", func() {
 			It("returns a timeout error and stops health API checker", func() {
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 500 * time.Millisecond
+				processState.URL = getServerURL(server)
 
-				url, err := url.Parse(server.URL())
-				Expect(err).NotTo(HaveOccurred())
-				processState.URL = *url
-
-				err = processState.Start(nil, nil)
+				err := processState.Start(nil, nil)
 				Expect(err).To(MatchError(ContainSubstring("timeout")))
 
 				nrReceivedRequests := len(server.ReceivedRequests())
@@ -124,12 +118,9 @@ var _ = Describe("Start method", func() {
 			It("hits the endpoint repeatedly, and successfully starts", func() {
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 20 * time.Second
+				processState.URL = getServerURL(server)
 
-				url, err := url.Parse(server.URL())
-				Expect(err).NotTo(HaveOccurred())
-				processState.URL = *url
-
-				err = processState.Start(nil, nil)
+				err := processState.Start(nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(server.ReceivedRequests()).To(HaveLen(4))
 				Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
@@ -139,10 +130,7 @@ var _ = Describe("Start method", func() {
 				It("uses the default interval for polling", func() {
 					processState.HealthCheckEndpoint = "/helathz"
 					processState.StartTimeout = 300 * time.Millisecond
-
-					url, err := url.Parse(server.URL())
-					Expect(err).NotTo(HaveOccurred())
-					processState.URL = *url
+					processState.URL = getServerURL(server)
 
 					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
 					Expect(server.ReceivedRequests()).To(HaveLen(3))
@@ -157,10 +145,7 @@ var _ = Describe("Start method", func() {
 				It("hits the endpoint in the configured interval", func() {
 					processState.HealthCheckEndpoint = "/healthz"
 					processState.StartTimeout = 3 * processState.HealthCheckPollInterval
-
-					url, err := url.Parse(server.URL())
-					Expect(err).NotTo(HaveOccurred())
-					processState.URL = *url
+					processState.URL = getServerURL(server)
 
 					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
 					Expect(server.ReceivedRequests()).To(HaveLen(3))
@@ -374,4 +359,10 @@ var simpleBashScript = []string{
 
 func getSimpleCommand() *exec.Cmd {
 	return exec.Command("bash", simpleBashScript...)
+}
+
+func getServerURL(server *ghttp.Server) url.URL {
+	url, err := url.Parse(server.URL())
+	Expect(err).NotTo(HaveOccurred())
+	return *url
 }

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Start method", func() {
 			BeforeEach(func() {
 				server.RouteToHandler("GET", "/healthz", ghttp.RespondWith(http.StatusInternalServerError, ""))
 			})
-			It("returns a timeout error", func() {
+			It("returns a timeout error and stops health API checker", func() {
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 500 * time.Millisecond
 
@@ -81,8 +81,14 @@ var _ = Describe("Start method", func() {
 
 				err = processState.Start(nil, nil)
 				Expect(err).To(MatchError(ContainSubstring("timeout")))
+
+				nrReceivedRequests := len(server.ReceivedRequests())
+				Expect(nrReceivedRequests).To(Equal(5))
+				time.Sleep(200 * time.Millisecond)
+				Expect(nrReceivedRequests).To(Equal(5))
 			})
 		})
+
 		Context("when the healthcheck isn't even listening", func() {
 			BeforeEach(func() {
 				server.Close()

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -18,10 +18,16 @@ import (
 )
 
 var _ = Describe("Start method", func() {
-	It("can start a process", func() {
-		processState := &ProcessState{}
+	var (
+		processState *ProcessState
+	)
+	BeforeEach(func() {
+		processState = &ProcessState{}
 		processState.Path = "bash"
 		processState.Args = simpleBashScript
+	})
+
+	It("can start a process", func() {
 		processState.StartTimeout = 10 * time.Second
 		processState.StartMessage = "loop 5"
 
@@ -47,9 +53,6 @@ var _ = Describe("Start method", func() {
 			})
 
 			It("hits the endpoint, and successfully starts", func() {
-				processState := &ProcessState{}
-				processState.Path = "bash"
-				processState.Args = simpleBashScript
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 100 * time.Millisecond
 
@@ -69,9 +72,6 @@ var _ = Describe("Start method", func() {
 				server.RouteToHandler("GET", "/healthz", ghttp.RespondWith(http.StatusInternalServerError, ""))
 			})
 			It("returns a timeout error", func() {
-				processState := &ProcessState{}
-				processState.Path = "bash"
-				processState.Args = simpleBashScript
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 500 * time.Millisecond
 
@@ -89,9 +89,6 @@ var _ = Describe("Start method", func() {
 			})
 
 			It("returns a timeout error", func() {
-				processState := &ProcessState{}
-				processState.Path = "bash"
-				processState.Args = simpleBashScript
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 500 * time.Millisecond
 
@@ -120,9 +117,6 @@ var _ = Describe("Start method", func() {
 			})
 
 			It("hits the endpoint repeatedly, and successfully starts", func() {
-				processState := &ProcessState{}
-				processState.Path = "bash"
-				processState.Args = simpleBashScript
 				processState.HealthCheckEndpoint = "/healthz"
 				processState.StartTimeout = 20 * time.Second
 
@@ -142,9 +136,6 @@ var _ = Describe("Start method", func() {
 
 		Context("when process takes too long to start", func() {
 			It("returns a timeout error", func() {
-				processState := &ProcessState{}
-				processState.Path = "bash"
-				processState.Args = simpleBashScript
 				processState.StartTimeout = 200 * time.Millisecond
 				processState.StartMessage = "loop 5000"
 
@@ -156,9 +147,6 @@ var _ = Describe("Start method", func() {
 		})
 
 		Context("when the command cannot be started", func() {
-			var (
-				processState *ProcessState
-			)
 			BeforeEach(func() {
 				processState = &ProcessState{}
 				processState.Path = "/nonexistent"
@@ -189,8 +177,6 @@ var _ = Describe("Start method", func() {
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
 
-			processState := &ProcessState{}
-			processState.Path = "bash"
 			processState.Args = []string{
 				"-c",
 				`


### PR DESCRIPTION
We found that the APIServer was not fully up when it logged "Serving
(in)securely on ...". We tried to find a different log line we can wait
for to know when the APIServer is fully up.

The autoregister controller came in with
https://github.com/kubernetes/kubernetes/pull/42732. It seems to be the
last thing to come up before the server is ready to go.

Is there a better thing to wait for, or is this a good indicator that the APIServer is ready to use?