### PR TITLE
Move to sigs.k8s.io/testing_frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.9.x
 
-go_import_path: github.com/kubernetes-sigs/testing_frameworks
+go_import_path: sigs.k8s.io/testing_frameworks
 
 before_install:
   - source ./bin/consider-early-travis-exit.sh

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	"sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 // APIServer knows how to run a kubernetes apiserver.

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -6,7 +6,7 @@ import (
 
 	"net/url"
 
-	"github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	"sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 // Etcd knows how to run an etcd server.

--- a/integration/internal/address_manager_test.go
+++ b/integration/internal/address_manager_test.go
@@ -1,7 +1,7 @@
 package internal_test
 
 import (
-	. "github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	. "sigs.k8s.io/testing_frameworks/integration/internal"
 
 	"fmt"
 	"net"

--- a/integration/internal/apiserver_test.go
+++ b/integration/internal/apiserver_test.go
@@ -1,9 +1,9 @@
 package internal_test
 
 import (
-	. "github.com/kubernetes-sigs/testing_frameworks/integration/internal"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 var _ = Describe("Apiserver", func() {

--- a/integration/internal/arguments_test.go
+++ b/integration/internal/arguments_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	. "sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 var _ = Describe("Arguments", func() {

--- a/integration/internal/etcd_test.go
+++ b/integration/internal/etcd_test.go
@@ -3,7 +3,7 @@ package internal_test
 import (
 	"net/url"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	. "sigs.k8s.io/testing_frameworks/integration/internal"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/integration/internal/integration_tests/apiserver_integration_test.go
+++ b/integration/internal/integration_tests/apiserver_integration_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration"
+	. "sigs.k8s.io/testing_frameworks/integration"
 )
 
 var _ = Describe("APIServer", func() {

--- a/integration/internal/integration_tests/etcd_integration_test.go
+++ b/integration/internal/integration_tests/etcd_integration_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration"
+	. "sigs.k8s.io/testing_frameworks/integration"
 )
 
 var _ = Describe("Etcd", func() {

--- a/integration/internal/integration_tests/integration_test.go
+++ b/integration/internal/integration_tests/integration_test.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/kubernetes-sigs/testing_frameworks/integration"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/testing_frameworks/integration"
 )
 
 var _ = Describe("The Testing Framework", func() {

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -10,11 +10,11 @@ import (
 	"os/exec"
 	"time"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration/internal"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
+	. "sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 var _ = Describe("Start method", func() {

--- a/integration/kubectl.go
+++ b/integration/kubectl.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os/exec"
 
-	"github.com/kubernetes-sigs/testing_frameworks/integration/internal"
+	"sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
 // KubeCtl is a wrapper around the kubectl binary.

--- a/integration/kubectl_test.go
+++ b/integration/kubectl_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/kubernetes-sigs/testing_frameworks/integration"
+	. "sigs.k8s.io/testing_frameworks/integration"
 )
 
 var _ = Describe("Kubectl", func() {


### PR DESCRIPTION
Now that sigs.k8s.io works, we should use that as our canonical import path.