### PR TITLE
Better UX for using additional arguments

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -113,4 +113,7 @@ func (s *APIServer) Stop() error {
 
 // APIServerDefaultArgs exposes the default args for the APIServer so that you
 // can use those to append your own additional arguments.
-var APIServerDefaultArgs = internal.APIServerDefaultArgs
+//
+// The internal default arguments are explicitely copied here, we don't want to
+// allow users to change the internal ones.
+var APIServerDefaultArgs = append([]string{}, internal.APIServerDefaultArgs...)

--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -110,3 +110,7 @@ func (s *APIServer) Start() error {
 func (s *APIServer) Stop() error {
 	return s.processState.Stop()
 }
+
+// APIServerDefaultArgs exposes the default args for the APIServer so that you
+// can use those to append your own additional arguments.
+var APIServerDefaultArgs = internal.APIServerDefaultArgs

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -88,7 +88,7 @@ arguments needed for the binary to start successfully.
 
 However, the default arguments for APIServer and Etcd are exported as
 `APIServerDefaultArgs` and `EtcdDefaultArgs` from this package. Treat those
-variables as read-only constants. Internally we have a use a set of default
+variables as read-only constants. Internally we have a set of default
 arguments for defaulting, the `APIServerDefaultArgs` and `EtcdDefaultArgs` are
 just copies of those. So when you override them you loose access to the actual
 internal default arguments, but your override won't affect the defaulting.

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -78,13 +78,20 @@ location (`${FRAMEWORK_DIR}/assets/bin/`).
 
 Arguments for Etcd and APIServer
 
-Those components will start without any configuration. However, if you want our
+Those components will start without any configuration. However, if you want or
 need to, you can override certain configuration -- one of which are the
 arguments used when calling the binary.
 
 When you choose to specify your own set of arguments, those won't be appended
 to the default set of arguments, it is your responsibility to provide all the
 arguments needed for the binary to start successfully.
+
+However, the default arguments for APIServer and Etcd are exported as
+`APIServerDefaultArgs` and `EtcdDefaultArgs` from this package. Treat those
+variables as read-only constants. Internally we have a use a set of default
+arguments for defaulting, the `APIServerDefaultArgs` and `EtcdDefaultArgs` are
+just copies of those. So when you override them you loose access to the actual
+internal default arguments, but your override won't affect the defaulting.
 
 All arguments are interpreted as go templates. Those templates have access to
 all exported fields of the `APIServer`/`Etcd` struct. It does not matter if
@@ -93,19 +100,18 @@ those fields where explicitly set up or if they were defaulted by calling the
 executed and right after the defaulting of all the struct's fields has
 happened.
 
-	// All arguments needed for a successful start must be specified
-	etcdArgs := []string{
-		"--listen-peer-urls=http://localhost:0",
-		"--advertise-client-urls={{ .URL.String }}",
-		"--listen-client-urls={{ .URL.String }}",
-		"--data-dir={{ .DataDir }}",
-		// add some custom arguments
-		"--this-is-my-very-important-custom-argument",
-		"--arguments-dont-have-to-be-templates=but they can",
+	// When you want to append additional arguments ...
+	etcd := &Etcd{
+		// Additional custom arguments will appended to the set of default
+		// arguments
+		Args:    append(EtcdDefaultArgs, "--additional=arg"),
+		DataDir: "/my/special/data/dir",
 	}
 
+	// When you want to use a custom set of arguments ...
 	etcd := &Etcd{
-		Args:    etcdArgs,
+		// Only custom arguments will be passed to the binary
+		Args:    []string{"--one=1", "--two=2", "--three=3"},
 		DataDir: "/my/special/data/dir",
 	}
 

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -100,3 +100,7 @@ func (e *Etcd) Start() error {
 func (e *Etcd) Stop() error {
 	return e.processState.Stop()
 }
+
+// EtcdDefaultArgs exposes the default args for Etcd so that you
+// can use those to append your own additional arguments.
+var EtcdDefaultArgs = internal.EtcdDefaultArgs

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -103,4 +103,7 @@ func (e *Etcd) Stop() error {
 
 // EtcdDefaultArgs exposes the default args for Etcd so that you
 // can use those to append your own additional arguments.
-var EtcdDefaultArgs = internal.EtcdDefaultArgs
+//
+// The internal default arguments are explicitely copied here, we don't want to
+// allow users to change the internal ones.
+var EtcdDefaultArgs = append([]string{}, internal.EtcdDefaultArgs...)

--- a/integration/internal/arguments_test.go
+++ b/integration/internal/arguments_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/testing_frameworks/integration"
 	. "sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
@@ -79,5 +80,16 @@ var _ = Describe("Arguments", func() {
 		Expect(err).To(MatchError(
 			ContainSubstring("can't evaluate field"),
 		))
+	})
+
+	Context("When overriding external default args", func() {
+		It("does not change the internal default args for APIServer", func() {
+			integration.APIServerDefaultArgs[0] = "oh no!"
+			Expect(APIServerDefaultArgs).NotTo(BeEquivalentTo(integration.APIServerDefaultArgs))
+		})
+		It("does not change the internal default args for Etcd", func() {
+			integration.EtcdDefaultArgs[0] = "oh no!"
+			Expect(EtcdDefaultArgs).NotTo(BeEquivalentTo(integration.EtcdDefaultArgs))
+		})
 	})
 })


### PR DESCRIPTION
@seans3 What do you think about exporting the default args, so you can just append to them?

@kubernetes-sigs/testing_frameworks-maintainers 

Closes: #55