### PR TITLE
make it work 1.12+ kube-apiserver --secure-port flag

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"time"
 
+	"sigs.k8s.io/testing_frameworks/integration/addr"
 	"sigs.k8s.io/testing_frameworks/integration/internal"
 )
 
@@ -15,6 +16,9 @@ type APIServer struct {
 	//
 	// If this is not specified, we default to a random free port on localhost.
 	URL *url.URL
+
+	// SecurePort is the additional secure port that the APIServer should listen on.
+	SecurePort int
 
 	// Path is the path to the apiserver binary.
 	//
@@ -85,6 +89,14 @@ func (s *APIServer) Start() error {
 	)
 	if err != nil {
 		return err
+	}
+
+	// Defaulting the secure port
+	if s.SecurePort == 0 {
+		s.SecurePort, _, err = addr.Suggest()
+		if err != nil {
+			return err
+		}
 	}
 
 	s.processState.HealthCheckEndpoint = "/healthz"

--- a/integration/internal/apiserver.go
+++ b/integration/internal/apiserver.go
@@ -5,7 +5,7 @@ var APIServerDefaultArgs = []string{
 	"--cert-dir={{ .CertDir }}",
 	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
-	"--secure-port=0",
+	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
 }
 
 func DoAPIServerArgDefaulting(args []string) []string {


### PR DESCRIPTION
From 1.12, kube-apiserver not longer accept `--secure-port=0`.
So we should make it use a random port.

```
--secure-port int     Default: 6443
The port on which to serve HTTPS with authentication and authorization.It cannot be switched off with 0.
```
Ref: https://v1-12.docs.kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/