### PR TITLE
check if control plane process is Ready before Start()-ing it again

### DIFF
--- a/integration/apiserver.go
+++ b/integration/apiserver.go
@@ -71,6 +71,15 @@ type APIServer struct {
 // Start starts the apiserver, waits for it to come up, and returns an error,
 // if occurred.
 func (s *APIServer) Start() error {
+	if s.processState == nil {
+		if err := s.setProcessState(); err != nil {
+			return err
+		}
+	}
+	return s.processState.Start(s.Out, s.Err)
+}
+
+func (s *APIServer) setProcessState() error {
 	if s.EtcdURL == nil {
 		return fmt.Errorf("expected EtcdURL to be configured")
 	}
@@ -110,11 +119,7 @@ func (s *APIServer) Start() error {
 	s.processState.Args, err = internal.RenderTemplates(
 		internal.DoAPIServerArgDefaulting(s.Args), s,
 	)
-	if err != nil {
-		return err
-	}
-
-	return s.processState.Start(s.Out, s.Err)
+	return err
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/etcd.go
+++ b/integration/etcd.go
@@ -61,6 +61,15 @@ type Etcd struct {
 // Start starts the etcd, waits for it to come up, and returns an error, if one
 // occoured.
 func (e *Etcd) Start() error {
+	if e.processState == nil {
+		if err := e.setProcessState(); err != nil {
+			return err
+		}
+	}
+	return e.processState.Start(e.Out, e.Err)
+}
+
+func (e *Etcd) setProcessState() error {
 	var err error
 
 	e.processState = &internal.ProcessState{}
@@ -88,11 +97,7 @@ func (e *Etcd) Start() error {
 	e.processState.Args, err = internal.RenderTemplates(
 		internal.DoEtcdArgDefaulting(e.Args), e,
 	)
-	if err != nil {
-		return err
-	}
-
-	return e.processState.Start(e.Out, e.Err)
+	return err
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/integration/internal/integration_tests/integration_test.go
+++ b/integration/internal/integration_tests/integration_test.go
@@ -98,6 +98,36 @@ var _ = Describe("The Testing Framework", func() {
 		})
 	})
 
+	Context("when etcd already started", func() {
+		It("starts the control plane successfully", func() {
+			myEtcd := &integration.Etcd{}
+			Expect(myEtcd.Start()).To(Succeed())
+
+			controlPlane = &integration.ControlPlane{
+				Etcd: myEtcd,
+			}
+
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
+	Context("when control plane is already started", func() {
+		It("can attempt to start again without errors", func() {
+			controlPlane = &integration.ControlPlane{}
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
+	Context("when control plane starts and stops", func() {
+		It("can attempt to start again without errors", func() {
+			controlPlane = &integration.ControlPlane{}
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Stop()).To(Succeed())
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
 	Measure("It should be fast to bring up and tear down the control plane", func(b Benchmarker) {
 		b.Time("lifecycle", func() {
 			controlPlane = &integration.ControlPlane{}

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -39,6 +39,8 @@ type ProcessState struct {
 	StartMessage string
 	Args         []string
 
+	// ready holds wether the process is currently in ready state (hit the ready condition) or not.
+	// It will be set to true on a successful `Start()` and set to false on a successful `Stop()`
 	ready bool
 }
 


### PR DESCRIPTION
fixes bug when retrying `controlPlane.Start()` here:
https://github.com/kubernetes-sigs/controller-runtime/blob/6101f6954a042342f1153c9b938813ad6995052c/pkg/envtest/server.go#L186

I noticed it when `Etcd.Start()` was successful and `APIServer.Start()` fails, it would retry, but the `etcd` port is already taken by the successful `Etcd.Start()`, so `Etcd.Start()` would continuously fail. Thought this is the best place to handle this type of error, as it seems like `ControlPlane.Start()` is meant to abstract all the `Start()` logic.