### PR TITLE
:bug: use net.JoinHostPort instead of Sprintf

### DIFF
--- a/integration/addr/manager_test.go
+++ b/integration/addr/manager_test.go
@@ -3,8 +3,8 @@ package addr_test
 import (
 	"sigs.k8s.io/testing_frameworks/integration/addr"
 
-	"fmt"
 	"net"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,10 +15,10 @@ var _ = Describe("SuggestAddress", func() {
 		port, host, err := addr.Suggest()
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(host).To(Equal("127.0.0.1"))
+		Expect(host).To(Or(Equal("127.0.0.1"), Equal("::1")))
 		Expect(port).NotTo(Equal(0))
 
-		addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", host, port))
+		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 		Expect(err).NotTo(HaveOccurred())
 		l, err := net.ListenTCP("tcp", addr)
 		defer func() {

--- a/integration/internal/etcd.go
+++ b/integration/internal/etcd.go
@@ -1,6 +1,8 @@
 package internal
 
-import "net/url"
+import (
+	"net/url"
+)
 
 var EtcdDefaultArgs = []string{
 	"--listen-peer-urls=http://localhost:0",
@@ -28,9 +30,9 @@ func isSecureScheme(scheme string) bool {
 func GetEtcdStartMessage(listenUrl url.URL) string {
 	if isSecureScheme(listenUrl.Scheme) {
 		// https://github.com/coreos/etcd/blob/a7f1fbe00ec216fcb3a1919397a103b41dca8413/embed/serve.go#L167
-		return "serving client requests on " + listenUrl.Hostname()
+		return "serving client requests on "
 	}
 
 	// https://github.com/coreos/etcd/blob/a7f1fbe00ec216fcb3a1919397a103b41dca8413/embed/serve.go#L124
-	return "serving insecure client requests on " + listenUrl.Hostname()
+	return "serving insecure client requests on "
 }

--- a/integration/internal/etcd_test.go
+++ b/integration/internal/etcd_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GetEtcdStartMessage()", func() {
 				Host:   "some.insecure.host:1234",
 			}
 			message := GetEtcdStartMessage(url)
-			Expect(message).To(Equal("serving insecure client requests on some.insecure.host"))
+			Expect(message).To(Equal("serving insecure client requests on "))
 		})
 	})
 	Context("when using a tls URL", func() {
@@ -43,7 +43,7 @@ var _ = Describe("GetEtcdStartMessage()", func() {
 				Host:   "some.secure.host:8443",
 			}
 			message := GetEtcdStartMessage(url)
-			Expect(message).To(Equal("serving client requests on some.secure.host"))
+			Expect(message).To(Equal("serving client requests on "))
 		})
 	})
 })

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
@@ -75,7 +77,7 @@ func DoDefaulting(
 		}
 		defaults.URL = url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("%s:%d", host, port),
+			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
 		}
 	} else {
 		defaults.URL = *listenUrl

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -2,12 +2,13 @@ package internal_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -97,7 +98,7 @@ var _ = Describe("Start method", func() {
 
 				processState.URL = url.URL{
 					Scheme: "http",
-					Host:   fmt.Sprintf("%s:%d", host, port),
+					Host:   net.JoinHostPort(host, strconv.Itoa(port)),
 				}
 
 				err = processState.Start(nil, nil)


### PR DESCRIPTION
`fmt.Sprintf` doesn't work well in IPV6 env.
e.g. we expect `[::1]:23456` instead of `::1:23456`.
See: https://golang.org/pkg/net/#JoinHostPort and https://golang.org/pkg/net/#SplitHostPort

Etcd health check is matching if `"serving client requests on " + listenUrl.Hostname()` show up in the stderr.
Ref: https://github.com/etcd-io/etcd/blob/8037e6e08727d4a17649f782cb4dbc482b8fe780/embed/serve.go#L144
It's a little brittle, since `listenUrl.Hostname()` returns an IPV6  address w/o `[]`, but stderr has `[]` around the address.
