### PR TITLE
Fix a failing test caused by an kubectl output change in 1.16

### DIFF
--- a/integration/internal/integration_tests/integration_test.go
+++ b/integration/internal/integration_tests/integration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("The Testing Framework", func() {
 		bytes, err := ioutil.ReadAll(stdout)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bytes).To(BeEmpty())
-		Expect(stderr).To(ContainSubstring("No resources found."))
+		Expect(stderr).To(ContainSubstring("No resources found"))
 
 		By("Stopping all the control plane processes")
 		err = controlPlane.Stop()


### PR DESCRIPTION
It used to output `No resources found.` in 1.15 and older.
It now output `No resources found in default name space.` which will cause the test to fail due to a period `.` difference.